### PR TITLE
fix organization slug not set

### DIFF
--- a/server/internal/api/application/organization.go
+++ b/server/internal/api/application/organization.go
@@ -169,6 +169,9 @@ func (oa *OrganizationApplication) GetInviteDetails(ctx context.Context, inviteI
 
 	organizationName := invite.OrganizationName
 	organizationSlug, err := oa.normalizationService.FormatToDNS1123(organizationName)
+	if err != nil {
+		return nil, err
+	}
 
 	return &value.OrganizationInvite{
 		Id:               invite.Id,

--- a/server/internal/api/application/organization.go
+++ b/server/internal/api/application/organization.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"starliner.app/internal/api/conf"
@@ -45,6 +46,8 @@ func NewOrganizationApplication(
 }
 
 func (oa *OrganizationApplication) CreateOrganization(ctx context.Context, name string, ownerID int64) (*value.Organization, error) {
+	name = strings.TrimSpace(name)
+
 	organizationSlug, err := oa.normalizationService.FormatToDNS1123(name)
 	if err != nil {
 		return nil, err
@@ -164,16 +167,14 @@ func (oa *OrganizationApplication) GetInviteDetails(ctx context.Context, inviteI
 		return nil, err
 	}
 
-	org, err := oa.organizationRepository.GetOrganization(ctx, invite.OrganizationId)
-	if err != nil {
-		return nil, err
-	}
+	organizationName := invite.OrganizationName
+	organizationSlug, err := oa.normalizationService.FormatToDNS1123(organizationName)
 
 	return &value.OrganizationInvite{
 		Id:               invite.Id,
 		OrganizationId:   invite.OrganizationId,
-		OrganizationSlug: org.Slug,
-		OrganizationName: org.Name,
+		OrganizationSlug: organizationSlug,
+		OrganizationName: organizationName,
 		Email:            invite.Email,
 		ExpiresAt:        invite.ExpiresAt,
 		CreatedAt:        invite.CreatedAt,

--- a/server/internal/api/application/organization.go
+++ b/server/internal/api/application/organization.go
@@ -164,8 +164,7 @@ func (oa *OrganizationApplication) GetInviteDetails(ctx context.Context, inviteI
 		return nil, err
 	}
 
-	organizationName := invite.OrganizationName
-	organizationSlug, err := oa.normalizationService.FormatToDNS1123(organizationName)
+	org, err := oa.organizationRepository.GetOrganization(ctx, invite.OrganizationId)
 	if err != nil {
 		return nil, err
 	}
@@ -173,8 +172,8 @@ func (oa *OrganizationApplication) GetInviteDetails(ctx context.Context, inviteI
 	return &value.OrganizationInvite{
 		Id:               invite.Id,
 		OrganizationId:   invite.OrganizationId,
-		OrganizationSlug: organizationSlug,
-		OrganizationName: organizationName,
+		OrganizationSlug: org.Slug,
+		OrganizationName: org.Name,
 		Email:            invite.Email,
 		ExpiresAt:        invite.ExpiresAt,
 		CreatedAt:        invite.CreatedAt,

--- a/server/internal/api/presentation/http/dto/response/organization.go
+++ b/server/internal/api/presentation/http/dto/response/organization.go
@@ -51,6 +51,7 @@ func NewOrganizationInvite(invite *value.OrganizationInvite) OrganizationInvite 
 	return OrganizationInvite{
 		Id:               invite.Id,
 		OrganizationId:   invite.OrganizationId,
+		OrganizationSlug: invite.OrganizationSlug,
 		OrganizationName: invite.OrganizationName,
 		Email:            invite.Email,
 		ExpiresAt:        invite.ExpiresAt.Format("2006-01-02T15:04:05Z07:00"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization names are now normalized (extra surrounding whitespace removed) before generating slugs, preventing malformed slugs.
  * Invite responses consistently include the organization slug so invite details reliably show the organization’s slug and name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->