### PR TITLE
235 add destructive dialog

### DIFF
--- a/client/app/components/organisms/dialog/DestructiveDialog.tsx
+++ b/client/app/components/organisms/dialog/DestructiveDialog.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Dialog, DialogContent } from "~/components/atoms/dialog/Dialog";
+import Button from "~/components/atoms/button/Button";
+
+interface DestructiveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+}
+
+export default function DestructiveDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Delete",
+  cancelLabel = "Cancel",
+  onConfirm,
+}: DestructiveDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <h1>{title}</h1>
+            <p className="text-mauve-11 text-sm">{description}</p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              intent="secondary"
+              className="w-24"
+              onClick={() => onOpenChange(false)}
+            >
+              {cancelLabel}
+            </Button>
+            <Button className="w-24" intent="danger" onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/app/components/organisms/dialog/DestructiveDialog.tsx
+++ b/client/app/components/organisms/dialog/DestructiveDialog.tsx
@@ -1,14 +1,17 @@
 import * as React from "react";
 import { Dialog, DialogContent } from "~/components/atoms/dialog/Dialog";
 import Button from "~/components/atoms/button/Button";
+import ErrorBanner from "~/components/atoms/banner/ErrorBanner";
 
 interface DestructiveDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
+  bannerText: string;
   description: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  isPending?: boolean;
   onConfirm: () => void;
 }
 
@@ -16,9 +19,11 @@ export default function DestructiveDialog({
   open,
   onOpenChange,
   title,
+  bannerText,
   description,
   confirmLabel = "Delete",
   cancelLabel = "Cancel",
+  isPending = false,
   onConfirm,
 }: DestructiveDialogProps) {
   return (
@@ -27,6 +32,7 @@ export default function DestructiveDialog({
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <h1>{title}</h1>
+            <ErrorBanner text={bannerText} />
             <p className="text-mauve-11 text-sm">{description}</p>
           </div>
           <div className="flex justify-end gap-2">
@@ -34,11 +40,17 @@ export default function DestructiveDialog({
               type="button"
               intent="secondary"
               className="w-24"
+              disabled={isPending}
               onClick={() => onOpenChange(false)}
             >
               {cancelLabel}
             </Button>
-            <Button className="w-24" intent="danger" onClick={onConfirm}>
+            <Button
+              className="w-24"
+              intent="primary"
+              onClick={onConfirm}
+              disabled={isPending}
+            >
               {confirmLabel}
             </Button>
           </div>

--- a/client/app/components/organisms/settings/organization/team/TeamDangerZone.tsx
+++ b/client/app/components/organisms/settings/organization/team/TeamDangerZone.tsx
@@ -1,12 +1,9 @@
 import React, { useState } from "react";
 import Button from "~/components/atoms/button/Button";
-import { Dialog, DialogContent } from "~/components/atoms/dialog/Dialog";
-import ErrorBanner from "~/components/atoms/banner/ErrorBanner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { useTRPC } from "~/utils/trpc/react";
 import { useOrganizationContext } from "~/contexts/OrganizationContext";
-import WarningBanner from "~/components/atoms/banner/WarningBanner";
 import DestructiveDialog from "~/components/organisms/dialog/DestructiveDialog";
 
 interface TeamDangerZoneProps {

--- a/client/app/components/organisms/settings/organization/team/TeamDangerZone.tsx
+++ b/client/app/components/organisms/settings/organization/team/TeamDangerZone.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 import { useTRPC } from "~/utils/trpc/react";
 import { useOrganizationContext } from "~/contexts/OrganizationContext";
 import WarningBanner from "~/components/atoms/banner/WarningBanner";
+import DestructiveDialog from "~/components/organisms/dialog/DestructiveDialog";
 
 interface TeamDangerZoneProps {
   teamId: number;
@@ -78,7 +79,7 @@ export default function TeamDangerZone({ teamId }: TeamDangerZoneProps) {
         </table>
       </div>
 
-      <Dialog
+      <DestructiveDialog
         open={showDeleteDialog}
         onOpenChange={(open) => {
           setShowDeleteDialog(open);
@@ -86,42 +87,16 @@ export default function TeamDangerZone({ teamId }: TeamDangerZoneProps) {
             deleteTeamMutation.reset();
           }
         }}
-      >
-        <DialogContent>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <h1>Delete Team</h1>
-              <WarningBanner text="Deleting the team will delete all projects that belong to the team, including the deployments." />
-              <p className="text-mauve-11 text-sm">
-                Are you sure you want to delete this team? This action cannot be
-                undone.
-              </p>
-            </div>
-            {deleteTeamMutation.isError && (
-              <ErrorBanner text={deleteTeamMutation.error.message} />
-            )}
-            <div className="flex justify-end gap-2">
-              <Button
-                type="button"
-                intent="secondary"
-                className="w-24"
-                disabled={deleteTeamMutation.isPending}
-                onClick={() => setShowDeleteDialog(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="w-24"
-                intent="primary"
-                disabled={deleteTeamMutation.isPending}
-                onClick={confirmDeleteTeam}
-              >
-                Delete
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+        title={"Delete Team"}
+        bannerText={
+          "Deleting the team will delete all projects that belong to the team, including the deployments."
+        }
+        description={
+          "Are you sure you want to delete this team? This action cannot be undone."
+        }
+        isPending={deleteTeamMutation.isPending}
+        onConfirm={confirmDeleteTeam}
+      />
     </>
   );
 }

--- a/client/app/routes/dashboard/clusters/[id]/settings.tsx
+++ b/client/app/routes/dashboard/clusters/[id]/settings.tsx
@@ -113,7 +113,11 @@ export default function Settings() {
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
         title="Delete this Cluster"
-        description="Are you sure you want to delete this cluster? This action cannot be undone and all associated resources will be permanently removed."
+        bannerText={
+          "Deleting this cluster will permanently delete all associated resources."
+        }
+        description="Are you sure you want to delete this cluster? This action cannot be undone."
+        isPending={deleteClusterMutation.isPending}
         onConfirm={() => deleteClusterMutation.mutate({ id: Number(id) })}
       />
     </>

--- a/client/app/routes/dashboard/clusters/[id]/settings.tsx
+++ b/client/app/routes/dashboard/clusters/[id]/settings.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Button from "~/components/atoms/button/Button";
 import { useTRPC } from "~/utils/trpc/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router";
 import { useOrganizationContext } from "~/contexts/OrganizationContext";
 import WarningBanner from "~/components/atoms/banner/WarningBanner";
+import DestructiveDialog from "~/components/organisms/dialog/DestructiveDialog";
 
 export default function Settings() {
   const navigate = useNavigate();
@@ -16,6 +17,8 @@ export default function Settings() {
     slug: string;
     id: string;
   }>();
+
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   const { data: hetznerCredentialData, isLoading: isCredentialLoading } =
     useQuery(
@@ -56,56 +59,63 @@ export default function Settings() {
             id: Number(id),
           }),
         });
+        setShowDeleteDialog(false);
         navigate(`/${slug}/clusters/${id}/general`);
       },
     }),
   );
 
   return (
-    <div className="w-full px-4">
-      {isCredentialLoading ? null : isCredentialValid ? null : (
-        <WarningBanner
-          text="You must enter your Hetzner API Key to delete the cluster."
-          linkOut={{
-            text: "API Keys",
-            href: `/${organization.slug}/settings/cluster/api-keys`,
-          }}
-          className="mt-4"
-        />
-      )}
-      <div className="w-full pt-4 shadow-xs">
-        <div className="border-mauve-6 rounded-md border text-sm">
-          <div className="border-mauve-6 text-mauve-12 bg-gray-2 flex h-14 items-center border-b px-4 text-xs uppercase">
-            Danger Zone
-          </div>
-          <div className="flex items-center justify-between px-4 py-2">
-            <div>
-              <p className="text-md font-bold">Delete this Cluster</p>
-              <p className="text-mauve-11 text-xs">
-                Once you delete a cluster, there is no going back. Please be
-                certain.
-              </p>
+    <>
+      <div className="w-full px-4">
+        {isCredentialLoading ? null : isCredentialValid ? null : (
+          <WarningBanner
+            text="You must enter your Hetzner API Key to delete the cluster."
+            linkOut={{
+              text: "API Keys",
+              href: `/${organization.slug}/settings/cluster/api-keys`,
+            }}
+            className="mt-4"
+          />
+        )}
+        <div className="w-full pt-4 shadow-xs">
+          <div className="border-mauve-6 rounded-md border text-sm">
+            <div className="border-mauve-6 text-mauve-12 bg-gray-2 flex h-14 items-center border-b px-4 text-xs uppercase">
+              Danger Zone
             </div>
-            <Button
-              className="w-36"
-              intent="danger"
-              disabled={
-                !isCredentialValid ||
-                clusterData?.status === "pending" ||
-                clusterData?.status === "deleted"
-              }
-              size="sm"
-              onClick={() =>
-                deleteClusterMutation.mutate({
-                  id: Number(id),
-                })
-              }
-            >
-              Delete this Cluster
-            </Button>
+            <div className="flex items-center justify-between px-4 py-2">
+              <div>
+                <p className="text-md font-bold">Delete this Cluster</p>
+                <p className="text-mauve-11 text-xs">
+                  Once you delete a cluster, there is no going back. Please be
+                  certain.
+                </p>
+              </div>
+              <Button
+                className="w-36"
+                intent="danger"
+                disabled={
+                  !isCredentialValid ||
+                  clusterData?.status === "pending" ||
+                  clusterData?.status === "deleted"
+                }
+                size="sm"
+                onClick={() => setShowDeleteDialog(true)}
+              >
+                Delete this Cluster
+              </Button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      <DestructiveDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title="Delete this Cluster"
+        description="Are you sure you want to delete this cluster? This action cannot be undone and all associated resources will be permanently removed."
+        onConfirm={() => deleteClusterMutation.mutate({ id: Number(id) })}
+      />
+    </>
   );
 }

--- a/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
+++ b/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
@@ -8,6 +8,7 @@ import Skeleton from "~/components/atoms/skeleton/Skeleton";
 import UpdateConnectedBranchForm from "~/components/organisms/forms/UpdateConnectedBranchForm";
 import Switch from "~/components/atoms/switch/Switch";
 import { Dialog, DialogContent } from "~/components/atoms/dialog/Dialog";
+import DestructiveDialog from "~/components/organisms/dialog/DestructiveDialog";
 
 export default function ProjectSettings() {
   const navigate = useNavigate();
@@ -76,6 +77,8 @@ export default function ProjectSettings() {
   const [pendingCheckedValue, setPendingCheckedValue] = useState<
     boolean | null
   >(null);
+  const [showDeleteEnvDialog, setShowDeleteEnvDialog] = useState(false);
+  const [showDeleteProjectDialog, setShowDeleteProjectDialog] = useState(false);
 
   useEffect(() => {
     if (!showPreviewEnvDialog) {
@@ -179,12 +182,7 @@ export default function ProjectSettings() {
                 environmentSlug === "production"
               }
               size="sm"
-              onClick={() => {
-                if (environmentId == null) return;
-                deleteEnvironmentMutation.mutate({
-                  id: environmentId,
-                });
-              }}
+              onClick={() => setShowDeleteEnvDialog(true)}
             >
               Delete this Environment
             </Button>
@@ -202,11 +200,7 @@ export default function ProjectSettings() {
               intent="danger"
               disabled={isClusterDataLoading}
               size="sm"
-              onClick={() =>
-                deleteProjectMutation.mutate({
-                  id: projectId,
-                })
-              }
+              onClick={() => setShowDeleteProjectDialog(true)}
             >
               Delete this Project
             </Button>
@@ -265,6 +259,25 @@ export default function ProjectSettings() {
           </div>
         </DialogContent>
       </Dialog>
+      <DestructiveDialog
+        open={showDeleteEnvDialog}
+        onOpenChange={setShowDeleteEnvDialog}
+        title="Delete this Environment"
+        description="Are you sure you want to delete this environment? This action cannot be undone."
+        isPending={deleteEnvironmentMutation.isPending}
+        onConfirm={() => {
+          if (environmentId == null) return;
+          deleteEnvironmentMutation.mutate({ id: environmentId });
+        }}
+      />
+
+      <DestructiveDialog
+        open={showDeleteProjectDialog}
+        onOpenChange={setShowDeleteProjectDialog}
+        title="Delete this Project"
+        description="Are you sure you want to delete this project? All environments and deployments associated with it will be permanently removed."
+        onConfirm={() => deleteProjectMutation.mutate({ id: projectId })}
+      />
     </>
   );
 }

--- a/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
+++ b/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
@@ -263,7 +263,11 @@ export default function ProjectSettings() {
         open={showDeleteEnvDialog}
         onOpenChange={setShowDeleteEnvDialog}
         title="Delete this Environment"
+        bannerText={
+          "Deleting this environment will permanently delete all deployments associated with it."
+        }
         description="Are you sure you want to delete this environment? This action cannot be undone."
+        isPending={deleteEnvironmentMutation.isPending}
         onConfirm={() => {
           if (environmentId == null) return;
           deleteEnvironmentMutation.mutate({ id: environmentId });
@@ -274,7 +278,11 @@ export default function ProjectSettings() {
         open={showDeleteProjectDialog}
         onOpenChange={setShowDeleteProjectDialog}
         title="Delete this Project"
-        description="Are you sure you want to delete this project? All environments and deployments associated with it will be permanently removed."
+        bannerText={
+          "Deleting this project will permanently delete all environments and deployments associated with it."
+        }
+        description="Are you sure you want to delete this project? This action cannot be undone."
+        isPending={deleteProjectMutation.isPending}
         onConfirm={() => deleteProjectMutation.mutate({ id: projectId })}
       />
     </>

--- a/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
+++ b/client/app/routes/dashboard/projects/[id]/[environment]/settings.tsx
@@ -264,7 +264,6 @@ export default function ProjectSettings() {
         onOpenChange={setShowDeleteEnvDialog}
         title="Delete this Environment"
         description="Are you sure you want to delete this environment? This action cannot be undone."
-        isPending={deleteEnvironmentMutation.isPending}
         onConfirm={() => {
           if (environmentId == null) return;
           deleteEnvironmentMutation.mutate({ id: environmentId });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized destructive confirmation dialog introduced for delete flows (clusters, projects, environments, teams) with configurable title, banner messaging, and button labels.
  * Delete actions now surface pending/disabled states while in progress.
  * After a successful cluster deletion, the UI navigates to the cluster's general settings page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/starlinerapp/starliner/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->