### PR TITLE
328 gray out nodes

### DIFF
--- a/client/app/components/atoms/nodes/DatabaseNode.tsx
+++ b/client/app/components/atoms/nodes/DatabaseNode.tsx
@@ -31,7 +31,7 @@ export default function DatabaseNode({
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
-        isDeleting && "pointer-events-none opacity-75 grayscale",
+        isDeleting && "pointer-events-none grayscale",
       )}
     >
       <Handle

--- a/client/app/components/atoms/nodes/DatabaseNode.tsx
+++ b/client/app/components/atoms/nodes/DatabaseNode.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import { Database, EllipsisVertical, Trash } from "~/components/atoms/icons";
@@ -24,11 +24,14 @@ export default function DatabaseNode({
   data,
   selected,
 }: NodeProps<DatabaseNode>) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
   return (
     <div
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
+        isDeleting && "pointer-events-none opacity-75 grayscale",
       )}
     >
       <Handle
@@ -42,7 +45,10 @@ export default function DatabaseNode({
             <Database className="w-5" />
             <p>{data.serviceName}</p>
           </div>
-          <DatabaseContextMenu deploymentId={data.id} />
+          <DatabaseContextMenu
+            deploymentId={data.id}
+            setIsDeleting={setIsDeleting}
+          />
         </div>
         <div>
           <div className="bg-gray-2 border-mauve-6 flex justify-between rounded-t-md border-1 p-2 text-sm shadow-md">
@@ -108,9 +114,13 @@ export default function DatabaseNode({
 
 interface DatabaseContextMenuProps {
   deploymentId: number;
+  setIsDeleting: (v: boolean) => void;
 }
 
-function DatabaseContextMenu({ deploymentId }: DatabaseContextMenuProps) {
+function DatabaseContextMenu({
+  deploymentId,
+  setIsDeleting,
+}: DatabaseContextMenuProps) {
   const trpc = useTRPC();
   const deleteDeploymentMutation = useMutation(
     trpc.deployment.deleteDeployment.mutationOptions(),
@@ -124,6 +134,7 @@ function DatabaseContextMenu({ deploymentId }: DatabaseContextMenuProps) {
   );
 
   function handleDeleteClicked() {
+    setIsDeleting(true);
     deleteDeploymentMutation.mutate(
       {
         id: deploymentId,
@@ -134,6 +145,9 @@ function DatabaseContextMenu({ deploymentId }: DatabaseContextMenuProps) {
             const parent = pathname.replace(/\/[^/]+\/?$/, "");
             navigate(parent, { relative: "path", replace: true });
           }
+        },
+        onError: () => {
+          setIsDeleting(false);
         },
       },
     );

--- a/client/app/components/atoms/nodes/GitNode.tsx
+++ b/client/app/components/atoms/nodes/GitNode.tsx
@@ -25,7 +25,7 @@ export default function GitNode({ data, selected }: NodeProps<GitNode>) {
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
-        isDeleting && "pointer-events-none opacity-75 grayscale",
+        isDeleting && "pointer-events-none grayscale",
       )}
     >
       <Handle

--- a/client/app/components/atoms/nodes/GitNode.tsx
+++ b/client/app/components/atoms/nodes/GitNode.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import { cn } from "~/utils/cn";
@@ -18,11 +18,14 @@ type GitNode = Node<{
 }>;
 
 export default function GitNode({ data, selected }: NodeProps<GitNode>) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
   return (
     <div
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
+        isDeleting && "pointer-events-none opacity-75 grayscale",
       )}
     >
       <Handle
@@ -43,7 +46,10 @@ export default function GitNode({ data, selected }: NodeProps<GitNode>) {
             <GitBranch className="w-5" />
             <p>{data.serviceName}</p>
           </div>
-          <GitContextMenu deploymentId={data.id} />
+          <GitContextMenu
+            deploymentId={data.id}
+            setIsDeleting={setIsDeleting}
+          />
         </div>
         <div>
           <div className="bg-gray-2 border-mauve-6 flex justify-between rounded-t-md border-1 p-2 text-sm shadow-md">
@@ -88,9 +94,10 @@ export default function GitNode({ data, selected }: NodeProps<GitNode>) {
 
 interface GitContextMenuProps {
   deploymentId: number;
+  setIsDeleting: (v: boolean) => void;
 }
 
-function GitContextMenu({ deploymentId }: GitContextMenuProps) {
+function GitContextMenu({ deploymentId, setIsDeleting }: GitContextMenuProps) {
   const trpc = useTRPC();
   const deleteDeploymentMutation = useMutation(
     trpc.deployment.deleteDeployment.mutationOptions(),
@@ -104,6 +111,7 @@ function GitContextMenu({ deploymentId }: GitContextMenuProps) {
   );
 
   function handleDeleteClicked() {
+    setIsDeleting(true);
     deleteDeploymentMutation.mutate(
       {
         id: deploymentId,
@@ -114,6 +122,9 @@ function GitContextMenu({ deploymentId }: GitContextMenuProps) {
             const parent = pathname.replace(/\/[^/]+\/?$/, "");
             navigate(parent, { relative: "path", replace: true });
           }
+        },
+        onError: () => {
+          setIsDeleting(false);
         },
       },
     );

--- a/client/app/components/atoms/nodes/ImageNode.tsx
+++ b/client/app/components/atoms/nodes/ImageNode.tsx
@@ -26,7 +26,7 @@ export default function ImageNode({ data, selected }: NodeProps<ImageNode>) {
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
-        isDeleting && "pointer-events-none opacity-75 grayscale",
+        isDeleting && "pointer-events-none grayscale",
       )}
     >
       <Handle

--- a/client/app/components/atoms/nodes/ImageNode.tsx
+++ b/client/app/components/atoms/nodes/ImageNode.tsx
@@ -2,7 +2,7 @@ import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import { Cube, EllipsisVertical, Trash } from "~/components/atoms/icons";
 import { cn } from "~/utils/cn";
 import CopyToClipboard from "~/components/atoms/copy-to-clipboard/CopyToClipboard";
-import React from "react";
+import React, { useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
 import { useTRPC } from "~/utils/trpc/react";
 import { useMutation } from "@tanstack/react-query";
@@ -19,11 +19,14 @@ type ImageNode = Node<{
 }>;
 
 export default function ImageNode({ data, selected }: NodeProps<ImageNode>) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
   return (
     <div
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
+        isDeleting && "pointer-events-none opacity-75 grayscale",
       )}
     >
       <Handle
@@ -44,7 +47,10 @@ export default function ImageNode({ data, selected }: NodeProps<ImageNode>) {
             <Cube className="w-5" />
             <p>{data.serviceName}</p>
           </div>
-          <ImageContextMenu deploymentId={data.id} />
+          <ImageContextMenu
+            deploymentId={data.id}
+            setIsDeleting={setIsDeleting}
+          />
         </div>
         <div>
           <div className="bg-gray-2 border-mauve-6 flex justify-between rounded-t-md border-1 p-2 text-sm shadow-md">
@@ -87,9 +93,13 @@ export default function ImageNode({ data, selected }: NodeProps<ImageNode>) {
 
 interface ImageContextMenuProps {
   deploymentId: number;
+  setIsDeleting: (v: boolean) => void;
 }
 
-function ImageContextMenu({ deploymentId }: ImageContextMenuProps) {
+function ImageContextMenu({
+  deploymentId,
+  setIsDeleting,
+}: ImageContextMenuProps) {
   const trpc = useTRPC();
   const deleteDeploymentMutation = useMutation(
     trpc.deployment.deleteDeployment.mutationOptions(),
@@ -103,6 +113,7 @@ function ImageContextMenu({ deploymentId }: ImageContextMenuProps) {
   );
 
   function handleDeleteClicked() {
+    setIsDeleting(true);
     deleteDeploymentMutation.mutate(
       {
         id: deploymentId,
@@ -113,6 +124,9 @@ function ImageContextMenu({ deploymentId }: ImageContextMenuProps) {
             const parent = pathname.replace(/\/[^/]+\/?$/, "");
             navigate(parent, { relative: "path", replace: true });
           }
+        },
+        onError: () => {
+          setIsDeleting(false);
         },
       },
     );

--- a/client/app/components/atoms/nodes/IngressNode.tsx
+++ b/client/app/components/atoms/nodes/IngressNode.tsx
@@ -1,7 +1,7 @@
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import { EllipsisVertical, Shuffle, Trash } from "~/components/atoms/icons";
 import CopyToClipboard from "~/components/atoms/copy-to-clipboard/CopyToClipboard";
-import React from "react";
+import React, { useState } from "react";
 import { useTRPC } from "~/utils/trpc/react";
 import { useMutation } from "@tanstack/react-query";
 import * as Popover from "@radix-ui/react-popover";
@@ -21,11 +21,14 @@ export default function IngressNode({
   data,
   selected,
 }: NodeProps<IngressNode>) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
   return (
     <div
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
+        isDeleting && "pointer-events-none opacity-75 grayscale",
       )}
     >
       <Handle
@@ -40,7 +43,10 @@ export default function IngressNode({
             <Shuffle className="w-5" />
             <p>{data.serviceName}</p>
           </div>
-          <IngressContextMenu deploymentId={data.id} />
+          <IngressContextMenu
+            deploymentId={data.id}
+            setIsDeleting={setIsDeleting}
+          />
         </div>
         <div>
           <div className="bg-white-a12 border-mauve-6 -mt-1.5 flex flex-col gap-2 rounded-md border-1 p-2 text-sm shadow-sm">
@@ -107,9 +113,13 @@ export default function IngressNode({
 
 interface IngressContextMenuProps {
   deploymentId: number;
+  setIsDeleting: (v: boolean) => void;
 }
 
-function IngressContextMenu({ deploymentId }: IngressContextMenuProps) {
+function IngressContextMenu({
+  deploymentId,
+  setIsDeleting,
+}: IngressContextMenuProps) {
   const trpc = useTRPC();
   const deleteDeploymentMutation = useMutation(
     trpc.deployment.deleteDeployment.mutationOptions(),
@@ -123,6 +133,8 @@ function IngressContextMenu({ deploymentId }: IngressContextMenuProps) {
   );
 
   function handleDeleteClicked() {
+    setIsDeleting(true);
+
     deleteDeploymentMutation.mutate(
       {
         id: deploymentId,
@@ -133,6 +145,9 @@ function IngressContextMenu({ deploymentId }: IngressContextMenuProps) {
             const parent = pathname.replace(/\/[^/]+\/?$/, "");
             navigate(parent, { relative: "path", replace: true });
           }
+        },
+        onError: () => {
+          setIsDeleting(false);
         },
       },
     );

--- a/client/app/components/atoms/nodes/IngressNode.tsx
+++ b/client/app/components/atoms/nodes/IngressNode.tsx
@@ -28,7 +28,7 @@ export default function IngressNode({
       className={cn(
         "bg-white-a12 text-mauve-11 hover:ring-violet-6 hover:rounded-md hover:ring-2",
         selected && "ring-violet-8 hover:ring-violet-8 rounded-md ring-2",
-        isDeleting && "pointer-events-none opacity-75 grayscale",
+        isDeleting && "pointer-events-none grayscale",
       )}
     >
       <Handle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes for database, Git, image, and ingress now show clear visual feedback (dimmed/grayscale and non-interactive) during deletion to indicate in-progress operations.

* **Bug Fixes**
  * Deletion error handling improved so failed deletions restore node interactivity and visual state, preventing stuck or permanently disabled nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->