### PR TITLE
#352 enable prometheus metrics for traefik

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,12 @@ services:
       - "--entrypoints.websecure.transport.respondingTimeouts.idleTimeout=600s"
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.entrypoint=metrics"
+      - "--metrics.prometheus.addentrypointslabels=true"
+      - "--metrics.prometheus.addrouterslabels=true"
+      - "--metrics.prometheus.addserviceslabels=true"
+      - "--entrypoints.metrics.address=:8082"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
Closes #352 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Prometheus metrics with a dedicated metrics endpoint available on port 8082.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->