### PR TITLE
don't show provisioning clusters on project creation

### DIFF
--- a/client/app/routes/dashboard/projects/new.tsx
+++ b/client/app/routes/dashboard/projects/new.tsx
@@ -118,7 +118,7 @@ export default function NewProject() {
         {selectedTeamHasNoClusters ? (
           organization.isOwner ? (
             <WarningBanner
-              text="This team has no clusters assigned. Create or assign a cluster, or wait for one to finish provisioning, before creating projects."
+              text="This team has no clusters assigned. Create or assign a cluster before creating projects."
               linkOut={{
                 text: "Create Cluster",
                 href: `/${organization.slug}/clusters/new`,
@@ -127,7 +127,7 @@ export default function NewProject() {
             />
           ) : (
             <WarningBanner
-              text="This team has no clusters assigned. Contact your admin to assign one, or wait for one to finish provisioning, before creating projects."
+              text="This team has no clusters assigned. Contact your admin to assign one before creating projects."
               className="my-2"
             />
           )

--- a/client/app/routes/dashboard/projects/new.tsx
+++ b/client/app/routes/dashboard/projects/new.tsx
@@ -42,6 +42,10 @@ export default function NewProject() {
     ),
   );
 
+  const readyClusters = clustersData?.filter(
+    (cluster) => cluster.status === "running",
+  );
+
   useEffect(() => {
     setValue("teamId", teamsData?.[0] ? String(teamsData[0].id) : "");
   }, [teamsData?.[0]?.id, setValue]);
@@ -49,9 +53,9 @@ export default function NewProject() {
   useEffect(() => {
     setValue(
       "clusterId",
-      clustersData?.[0] ? String(clustersData[0].clusterId) : "",
+      readyClusters?.[0] ? String(readyClusters[0].clusterId) : "",
     );
-  }, [clustersData?.[0]?.clusterId, setValue]);
+  }, [readyClusters?.[0]?.clusterId, setValue]);
 
   const isLoading = isClustersLoading || isTeamsLoading;
 
@@ -76,7 +80,7 @@ export default function NewProject() {
     });
   };
 
-  const clusterExists = clustersData && clustersData.length > 0;
+  const clusterExists = readyClusters && readyClusters.length > 0;
   const teamExists = teamsData && teamsData.length > 0;
   const selectedTeamHasNoClusters =
     !!teamIdInput && teamExists && !clusterExists && !isLoading;
@@ -114,7 +118,7 @@ export default function NewProject() {
         {selectedTeamHasNoClusters ? (
           organization.isOwner ? (
             <WarningBanner
-              text="This team has no clusters assigned. Create or assign a cluster before creating projects."
+              text="This team has no clusters assigned. Create or assign a cluster, or wait for one to finish provisioning, before creating projects."
               linkOut={{
                 text: "Create Cluster",
                 href: `/${organization.slug}/clusters/new`,
@@ -123,7 +127,7 @@ export default function NewProject() {
             />
           ) : (
             <WarningBanner
-              text="This team has no clusters assigned. Contact your admin to assign one before creating projects."
+              text="This team has no clusters assigned. Contact your admin to assign one, or wait for one to finish provisioning, before creating projects."
               className="my-2"
             />
           )
@@ -191,7 +195,7 @@ export default function NewProject() {
                     <option value="" disabled>
                       Cluster*
                     </option>
-                    {clustersData.map((cluster, i) => (
+                    {readyClusters.map((cluster, i) => (
                       <option key={i} value={cluster.clusterId}>
                         {cluster.clusterName}
                       </option>

--- a/client/app/routes/dashboard/projects/new.tsx
+++ b/client/app/routes/dashboard/projects/new.tsx
@@ -38,13 +38,7 @@ export default function NewProject() {
   const { data: clustersData, isLoading: isClustersLoading } = useQuery(
     trpc.team.getTeamClusters.queryOptions(
       { teamId: Number(teamIdInput) },
-      {
-        enabled: !!teamIdInput,
-        refetchInterval: (query) =>
-          query.state.data?.some((cluster) => cluster.status === "pending")
-            ? 2000
-            : false,
-      },
+      { enabled: !!teamIdInput },
     ),
   );
 

--- a/client/app/routes/dashboard/projects/new.tsx
+++ b/client/app/routes/dashboard/projects/new.tsx
@@ -38,7 +38,13 @@ export default function NewProject() {
   const { data: clustersData, isLoading: isClustersLoading } = useQuery(
     trpc.team.getTeamClusters.queryOptions(
       { teamId: Number(teamIdInput) },
-      { enabled: !!teamIdInput },
+      {
+        enabled: !!teamIdInput,
+        refetchInterval: (query) =>
+          query.state.data?.some((cluster) => cluster.status === "pending")
+            ? 2000
+            : false,
+      },
     ),
   );
 

--- a/client/app/server/api/clients/server/generated/api.ts
+++ b/client/app/server/api/clients/server/generated/api.ts
@@ -1666,11 +1666,18 @@ export interface ResponseTeamCluster {
   serverType: string;
   /**
    *
+   * @type {ResponseClusterStatus}
+   * @memberof ResponseTeamCluster
+   */
+  status: ResponseClusterStatus;
+  /**
+   *
    * @type {number}
    * @memberof ResponseTeamCluster
    */
   teamId: number;
 }
+
 /**
  *
  * @export

--- a/server/cmd/api/core/docs/core_core_docs.go
+++ b/server/cmd/api/core/docs/core_core_docs.go
@@ -3459,6 +3459,7 @@ const docTemplatecoreCore = `{
                 "clusterId",
                 "clusterName",
                 "serverType",
+                "status",
                 "teamId"
             ],
             "properties": {
@@ -3470,6 +3471,18 @@ const docTemplatecoreCore = `{
                 },
                 "serverType": {
                     "type": "string"
+                },
+                "status": {
+                    "enum": [
+                        "pending",
+                        "running",
+                        "deleted"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/response.ClusterStatus"
+                        }
+                    ]
                 },
                 "teamId": {
                     "type": "integer"

--- a/server/cmd/api/core/docs/core_core_swagger.json
+++ b/server/cmd/api/core/docs/core_core_swagger.json
@@ -3450,6 +3450,7 @@
                 "clusterId",
                 "clusterName",
                 "serverType",
+                "status",
                 "teamId"
             ],
             "properties": {
@@ -3461,6 +3462,18 @@
                 },
                 "serverType": {
                     "type": "string"
+                },
+                "status": {
+                    "enum": [
+                        "pending",
+                        "running",
+                        "deleted"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/response.ClusterStatus"
+                        }
+                    ]
                 },
                 "teamId": {
                     "type": "integer"

--- a/server/cmd/api/core/docs/core_core_swagger.yaml
+++ b/server/cmd/api/core/docs/core_core_swagger.yaml
@@ -870,12 +870,20 @@ definitions:
         type: string
       serverType:
         type: string
+      status:
+        allOf:
+        - $ref: '#/definitions/response.ClusterStatus'
+        enum:
+        - pending
+        - running
+        - deleted
       teamId:
         type: integer
     required:
     - clusterId
     - clusterName
     - serverType
+    - status
     - teamId
     type: object
   response.TeamRepo:

--- a/server/internal/api/application/project.go
+++ b/server/internal/api/application/project.go
@@ -12,6 +12,7 @@ type ProjectApplication struct {
 	normalizerService     *coreService.NormalizerService
 	organizationService   *service.OrganizationService
 	teamService           *service.TeamService
+	clusterService        *service.ClusterService
 	projectRepository     interfaces.ProjectRepository
 	environmentRepository interfaces.EnvironmentRepository
 	environmentService    *service.EnvironmentService
@@ -21,6 +22,7 @@ func NewProjectApplication(
 	normalizerService *coreService.NormalizerService,
 	organizationService *service.OrganizationService,
 	teamService *service.TeamService,
+	clusterService *service.ClusterService,
 	projectRepository interfaces.ProjectRepository,
 	environmentRepository interfaces.EnvironmentRepository,
 	environmentService *service.EnvironmentService,
@@ -29,6 +31,7 @@ func NewProjectApplication(
 		normalizerService:     normalizerService,
 		organizationService:   organizationService,
 		teamService:           teamService,
+		clusterService:        clusterService,
 		projectRepository:     projectRepository,
 		environmentRepository: environmentRepository,
 		environmentService:    environmentService,
@@ -41,7 +44,7 @@ func (pa *ProjectApplication) CreateProject(ctx context.Context, name string, cl
 		return nil, err
 	}
 
-	if err := pa.teamService.ValidateClusterReady(ctx, teamId, clusterId); err != nil {
+	if err := pa.clusterService.ValidateClusterReady(ctx, clusterId); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/api/application/project.go
+++ b/server/internal/api/application/project.go
@@ -41,6 +41,10 @@ func (pa *ProjectApplication) CreateProject(ctx context.Context, name string, cl
 		return nil, err
 	}
 
+	if err := pa.teamService.ValidateClusterReady(ctx, teamId, clusterId); err != nil {
+		return nil, err
+	}
+
 	namespace, err := pa.normalizerService.FormatToDNS1123(name + "-" + value.EnvironmentProductionName)
 	if err != nil {
 		return nil, err

--- a/server/internal/api/domain/entity/team_cluster.go
+++ b/server/internal/api/domain/entity/team_cluster.go
@@ -5,4 +5,5 @@ type TeamCluster struct {
 	ClusterId   int64
 	ClusterName string
 	ServerType  string
+	Status      ClusterStatus
 }

--- a/server/internal/api/domain/repository/team.go
+++ b/server/internal/api/domain/repository/team.go
@@ -215,6 +215,7 @@ func (tr *TeamRepository) GetTeamClusters(ctx context.Context, teamID int64) ([]
 			ClusterId:   row.ID,
 			ClusterName: row.Name,
 			ServerType:  row.ServerType,
+			Status:      entity.ClusterStatus(row.Status),
 		}
 	}
 	return clusters, nil
@@ -270,6 +271,7 @@ func (tr *TeamRepository) GetTeamCluster(ctx context.Context, teamID int64, clus
 		ClusterId:   cluster.ID,
 		ClusterName: cluster.Name,
 		ServerType:  cluster.ServerType,
+		Status:      entity.ClusterStatus(cluster.Status),
 	}, nil
 }
 

--- a/server/internal/api/domain/service/cluster.go
+++ b/server/internal/api/domain/service/cluster.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"starliner.app/internal/api/domain/entity"
+	_interface "starliner.app/internal/api/domain/repository/interface"
+)
+
+type ClusterService struct {
+	clusterRepository _interface.ClusterRepository
+}
+
+func NewClusterService(
+	clusterRepository _interface.ClusterRepository,
+) *ClusterService {
+	return &ClusterService{
+		clusterRepository: clusterRepository,
+	}
+}
+
+func (cs *ClusterService) ValidateClusterReady(ctx context.Context, clusterId int64) error {
+	cluster, err := cs.clusterRepository.GetCluster(ctx, clusterId)
+	if err != nil {
+		return err
+	}
+	if cluster.Status != entity.ClusterRunning {
+		return errors.New("cluster is not ready")
+	}
+	return nil
+}

--- a/server/internal/api/domain/service/module.go
+++ b/server/internal/api/domain/service/module.go
@@ -11,6 +11,7 @@ var Module = fx.Module(
 		NewEnvironmentService,
 		NewDeploymentService,
 		NewTeamService,
+		NewClusterService,
 		NewParserService,
 		NewResolverService,
 	),

--- a/server/internal/api/domain/service/team.go
+++ b/server/internal/api/domain/service/team.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
+
+	"starliner.app/internal/api/domain/entity"
 	_interface "starliner.app/internal/api/domain/repository/interface"
 )
 
@@ -36,6 +39,17 @@ func (os *TeamService) ValidateUserAndClusterInTeam(ctx context.Context, userId 
 	_, err = os.teamRepository.GetTeamCluster(ctx, teamId, clusterId)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (os *TeamService) ValidateClusterReady(ctx context.Context, teamId int64, clusterId int64) error {
+	cluster, err := os.teamRepository.GetTeamCluster(ctx, teamId, clusterId)
+	if err != nil {
+		return err
+	}
+	if cluster.Status != entity.ClusterRunning {
+		return errors.New("cluster is not ready")
 	}
 	return nil
 }

--- a/server/internal/api/domain/service/team.go
+++ b/server/internal/api/domain/service/team.go
@@ -2,9 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
 
-	"starliner.app/internal/api/domain/entity"
 	_interface "starliner.app/internal/api/domain/repository/interface"
 )
 
@@ -39,17 +37,6 @@ func (os *TeamService) ValidateUserAndClusterInTeam(ctx context.Context, userId 
 	_, err = os.teamRepository.GetTeamCluster(ctx, teamId, clusterId)
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-func (os *TeamService) ValidateClusterReady(ctx context.Context, teamId int64, clusterId int64) error {
-	cluster, err := os.teamRepository.GetTeamCluster(ctx, teamId, clusterId)
-	if err != nil {
-		return err
-	}
-	if cluster.Status != entity.ClusterRunning {
-		return errors.New("cluster is not ready")
 	}
 	return nil
 }

--- a/server/internal/api/domain/value/team_cluster.go
+++ b/server/internal/api/domain/value/team_cluster.go
@@ -7,6 +7,7 @@ type TeamCluster struct {
 	ClusterId   int64
 	ClusterName string
 	ServerType  string
+	Status      ClusterStatus
 }
 
 func NewTeamCluster(tc *entity.TeamCluster) *TeamCluster {
@@ -15,6 +16,7 @@ func NewTeamCluster(tc *entity.TeamCluster) *TeamCluster {
 		ClusterId:   tc.ClusterId,
 		ClusterName: tc.ClusterName,
 		ServerType:  tc.ServerType,
+		Status:      mapStatus(tc.Status),
 	}
 }
 

--- a/server/internal/api/presentation/http/dto/response/team_cluster.go
+++ b/server/internal/api/presentation/http/dto/response/team_cluster.go
@@ -3,10 +3,11 @@ package response
 import "starliner.app/internal/api/domain/value"
 
 type TeamCluster struct {
-	TeamID      int64  `json:"teamId" binding:"required"`
-	ClusterID   int64  `json:"clusterId" binding:"required"`
-	ClusterName string `json:"clusterName" binding:"required"`
-	ServerType  string `json:"serverType" binding:"required"`
+	TeamID      int64         `json:"teamId" binding:"required"`
+	ClusterID   int64         `json:"clusterId" binding:"required"`
+	ClusterName string        `json:"clusterName" binding:"required"`
+	ServerType  string        `json:"serverType" binding:"required"`
+	Status      ClusterStatus `json:"status" binding:"required,oneof=pending running deleted"`
 }
 
 func NewTeamCluster(tc *value.TeamCluster) TeamCluster {
@@ -15,6 +16,7 @@ func NewTeamCluster(tc *value.TeamCluster) TeamCluster {
 		ClusterID:   tc.ClusterId,
 		ClusterName: tc.ClusterName,
 		ServerType:  tc.ServerType,
+		Status:      ClusterStatus(tc.Status),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project creation now lists only running clusters for selection.

* **Improvements**
  * Prevents creating projects on clusters that aren’t ready.
  * Updated warning messages: advise waiting for provisioning and, for non-owners, contacting an admin.

* **Documentation**
  * API docs now include a required cluster status field (pending / running / deleted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->