### PR TITLE
415 fix canvas not rendering when cloning an environment

### DIFF
--- a/client/app/components/atoms/live-indicator/LiveIndicator.tsx
+++ b/client/app/components/atoms/live-indicator/LiveIndicator.tsx
@@ -6,21 +6,13 @@ interface LiveIndicatorProps {
 
 export default function LiveIndicator({ type }: LiveIndicatorProps) {
   return (
-    <span className="relative flex size-3">
+    <span className="relative flex size-2">
       <span
         className={cn(
-          "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+          "absolute inline-flex h-full w-full rounded-full opacity-75",
           type === "warning" && "bg-amber-10",
           type === "success" && "bg-grass-10",
           type === "error" && "bg-red-10",
-        )}
-      ></span>
-      <span
-        className={cn(
-          "relative inline-flex size-3 rounded-full",
-          type === "warning" && "bg-amber-9",
-          type === "success" && "bg-grass-9",
-          type === "error" && "bg-red-9",
         )}
       ></span>
     </span>

--- a/client/app/components/organisms/environments/ManageEnvironments.tsx
+++ b/client/app/components/organisms/environments/ManageEnvironments.tsx
@@ -224,6 +224,7 @@ export default function ManageEnvironments({
               <Button
                 intent="secondary"
                 className="w-24"
+                type="button"
                 onClick={() => {
                   reset();
                   setEnvironmentDialogOpen(false);

--- a/client/app/components/organisms/environments/ManageEnvironments.tsx
+++ b/client/app/components/organisms/environments/ManageEnvironments.tsx
@@ -49,11 +49,33 @@ export default function ManageEnvironments({
   const createEnvironmentMutation = useMutation(
     trpc.environment.createEnvironment.mutationOptions({
       onSuccess: async (data) => {
-        await queryClient.invalidateQueries({
-          queryKey: trpc.organization.getUserProjects.queryKey({
+        const projectId = project?.id ?? Number(id);
+
+        queryClient.setQueryData(
+          trpc.organization.getUserProjects.queryKey({
             id: organization.id,
           }),
-        });
+          (old) => {
+            if (!old) return old;
+            return old.map((p) =>
+              p.id === projectId
+                ? { ...p, environments: [...p.environments, data] }
+                : p,
+            );
+          },
+        );
+
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: trpc.organization.getUserProjects.queryKey({
+              id: organization.id,
+            }),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.project.getProject.queryKey({ id: projectId }),
+          }),
+        ]);
+
         navigate(`/${slug}/projects/${id}/${data.slug}/architecture/git`);
       },
     }),

--- a/client/app/routes/dashboard/clusters/[id]/general.tsx
+++ b/client/app/routes/dashboard/clusters/[id]/general.tsx
@@ -65,7 +65,7 @@ export default function General() {
 
   const statusMap = {
     pending: "Creating",
-    running: "Live",
+    running: "Online",
     deleted: "Deleting",
   };
   const status = statusMap[clusterData?.status ?? "pending"];
@@ -97,7 +97,7 @@ export default function General() {
                 {isLoading ? (
                   <Skeleton className="h-5 w-24" />
                 ) : (
-                  <span className="flex items-center gap-3">
+                  <span className="flex items-center gap-2">
                     <LiveIndicator type={liveIndicatorType} />
                     <p className="pr-2 text-mauve-11 capitalize">{status}</p>
                   </span>

--- a/client/app/routes/dashboard/projects/[id]/[environment]/architecture/layout.tsx
+++ b/client/app/routes/dashboard/projects/[id]/[environment]/architecture/layout.tsx
@@ -11,6 +11,7 @@ import {
 import BottomBar from "~/components/organisms/bottom-bar/deployment/BottomBar";
 import ArchitectureCanvas from "~/components/organisms/canvas/ArchitectureCanvas";
 import LinkNavigationBar from "~/components/organisms/navigation-bar/LinkNavigationBar";
+import { useOrganizationContext } from "~/contexts/OrganizationContext";
 import type { ResponseEnvironment } from "~/server/api/clients/server/generated";
 import { useTRPC } from "~/utils/trpc/react";
 
@@ -22,6 +23,7 @@ type ContextType = {
 
 export default function Layout() {
   const trpc = useTRPC();
+  const organization = useOrganizationContext();
   const { slug, id, environment, deploymentId } = useParams<{
     slug: string;
     id: string;
@@ -29,8 +31,13 @@ export default function Layout() {
     deploymentId: string;
   }>();
 
-  const { data: project } = useQuery(
-    trpc.project.getProject.queryOptions({ id: Number(id) }),
+  const { data: projects } = useQuery(
+    trpc.organization.getUserProjects.queryOptions({ id: organization.id }),
+  );
+
+  const project = useMemo(
+    () => projects?.find((p) => p.id === Number(id)),
+    [projects, id],
   );
 
   const currentEnvironment = useMemo(


### PR DESCRIPTION
ManageEnvironments only invalidated getUserProjects on create, but the architecture layout looked up the current environment via a separate getProject query. That cache never included the new environment, so currentEnvironment stayed undefined, the ReactFlowProvider never mounted, and the canvas was blank until a full refresh refetched getProject.

Closes #415 